### PR TITLE
Initial codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Eduardo-Ortega102 @raulanatol

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Eduardo-Ortega102 @raulanatol
+* @Eduardo-Ortega102 @JonayGarcia @raulanatol


### PR DESCRIPTION
He añadido un fichero CODEOWNERS usado para auto-asignar revisores en los repos. 

Faltaría añadir al resto de integrantes del equipo.